### PR TITLE
flake: nixosTest -> runNixOSTest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
               testFinished = "${home}/test-finished";
               testLog = "${home}/test.log";
             in
-            pkgs.nixosTest {
+            pkgs.testers.runNixOSTest {
               name = "hyprland-go";
 
               nodes.machine =


### PR DESCRIPTION
`pkgs.nixosTest` will be deprecated: https://github.com/NixOS/nixpkgs/pull/293891.