### PR TITLE
Add event.Close()

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -36,6 +36,11 @@ func NewEventClient(socket string) (*EventClient, error) {
 	return &EventClient{conn: conn}, nil
 }
 
+// Close the underlying connection.
+func (c *EventClient) Close() error {
+	return c.conn.Close()
+}
+
 // Low-level receive event method, should be avoided unless there is no
 // alternative.
 func (c *EventClient) Receive() ([]ReceivedData, error) {

--- a/event/event.go
+++ b/event/event.go
@@ -20,15 +20,15 @@ const (
 // automatically find the proper socket to connect and use the
 // HYPRLAND_INSTANCE_SIGNATURE for the current user.
 // If you need to connect to arbitrary user instances or need a method that
-// will not panic on error, use [NewEventClient] instead.
-func MustEventClient() *EventClient {
-	return assert.Must1(NewEventClient(helpers.MustSocket(".socket2.sock")))
+// will not panic on error, use [NewClient] instead.
+func MustClient() *EventClient {
+	return assert.Must1(NewClient(helpers.MustSocket(".socket2.sock")))
 }
 
 // Initiate a new event client.
 // Receive as parameters a socket that is generally localised in
 // '$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock'.
-func NewEventClient(socket string) (*EventClient, error) {
+func NewClient(socket string) (*EventClient, error) {
 	conn, err := net.Dial("unix", socket)
 	if err != nil {
 		return nil, fmt.Errorf("error while connecting to socket: %w", err)

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -31,7 +31,8 @@ func TestReceive(t *testing.T) {
 	}()
 
 	// We must capture this event
-	c := MustEventClient()
+	c := MustClient()
+	defer c.Close()
 	data, err := c.Receive()
 
 	assert.NoError(t, err)

--- a/examples/events/events.go
+++ b/examples/events/events.go
@@ -20,7 +20,9 @@ func (e *ev) ActiveWindow(w event.ActiveWindow) {
 }
 
 func main() {
-	c := event.MustEventClient()
+	c := event.MustClient()
+	defer c.Close()
+
 	event.Subscribe(
 		c, &ev{},
 		event.EventWorkspace,


### PR DESCRIPTION
This is the first breaking change in the API, but there is more to come.