### PR TITLE
Refactor event API again

### DIFF
--- a/event/event_test.go
+++ b/event/event_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestReceive(t *testing.T) {
 	// We must capture this event
 	c := MustClient()
 	defer c.Close()
-	data, err := c.Receive()
+	data, err := c.Receive(context.Background())
 
 	assert.NoError(t, err)
 	assert.True(t, len(data) >= 0)
@@ -46,11 +47,11 @@ func TestReceive(t *testing.T) {
 func TestSubscribe(t *testing.T) {
 	h := &FakeEventHandler{t: t}
 	c := &FakeEventClient{}
-	err := receiveAndProcessEvent(c, h, AllEvents...)
+	err := receiveAndProcessEvent(context.Background(), c, h, AllEvents...)
 	assert.NoError(t, err)
 }
 
-func (f *FakeEventClient) Receive() ([]ReceivedData, error) {
+func (f *FakeEventClient) Receive(context.Context) ([]ReceivedData, error) {
 	return []ReceivedData{
 		{
 			Type: EventWorkspace,

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -31,11 +31,11 @@ func TestReceive(t *testing.T) {
 		c.Dispatch("exec kitty sh -c 'echo Testing hyprland-go events && sleep 1'")
 	}()
 
-	// We must capture this event
 	c := MustClient()
 	defer c.Close()
 	data, err := c.Receive(context.Background())
 
+	// We must capture the event
 	assert.NoError(t, err)
 	assert.True(t, len(data) >= 0)
 	for _, d := range data {
@@ -44,7 +44,7 @@ func TestReceive(t *testing.T) {
 	}
 }
 
-func TestSubscribe(t *testing.T) {
+func TestProcessEvent(t *testing.T) {
 	h := &FakeEventHandler{t: t}
 	c := &FakeEventClient{}
 	err := receiveAndProcessEvent(context.Background(), c, h, AllEvents...)

--- a/event/event_types.go
+++ b/event/event_types.go
@@ -8,12 +8,11 @@ import (
 // EventClient is the event struct from hyprland-go.
 type EventClient struct {
 	conn net.Conn
-	ctx  context.Context
 }
 
 // Event Client interface, right now only used for testing.
 type eventClient interface {
-	Receive() ([]ReceivedData, error)
+	Receive(context.Context) ([]ReceivedData, error)
 }
 
 type RawData string

--- a/examples/events/events.go
+++ b/examples/events/events.go
@@ -2,7 +2,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/thiagokokada/hyprland-go/event"
 )
@@ -20,13 +22,22 @@ func (e *ev) ActiveWindow(w event.ActiveWindow) {
 }
 
 func main() {
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		5*time.Second,
+	)
+	defer cancel()
+
 	c := event.MustClient()
 	defer c.Close()
 
+	// Will listen for events for 5 seconds and exit
 	c.Subscribe(
+		ctx,
 		&ev{},
 		event.EventWorkspace,
 		event.EventActiveWindow,
 	)
 
+	fmt.Println("Bye!")
 }


### PR DESCRIPTION
- Remove previous context from `NewClient()` since it would only be useful during socket connection
- Add a context for `Receive()` and `Subscribe()` methods that works more how you would expect (cancel the read if the context is done)