### PR TITLE
event/event_test: add BenchmarkReceive

### DIFF
--- a/event/event_types.go
+++ b/event/event_types.go
@@ -1,13 +1,15 @@
 package event
 
 import (
+	"bufio"
 	"context"
 	"net"
 )
 
 // EventClient is the event struct from hyprland-go.
 type EventClient struct {
-	conn net.Conn
+	conn   net.Conn
+	reader *bufio.Reader
 }
 
 // Event Client interface, right now only used for testing.


### PR DESCRIPTION
This was supposed to be an optimisation in the `event.Receive()`, but benchmark shows that there is no advantage of complicating the code.

Let's add at least the benchmark in the test suite, since having benchmark is important to avoid optimising the wrong things.