### PR TITLE
event.Receive() optimisations

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"net"
@@ -103,8 +102,7 @@ func readWithContext(ctx context.Context, conn net.Conn, buf []byte) (int, error
 
 	// Start a goroutine to perform the read
 	go func() {
-		reader := bufio.NewReader(conn)
-		n, err = reader.Read(buf)
+		n, err = conn.Read(buf)
 		close(done)
 	}()
 

--- a/event/event_types.go
+++ b/event/event_types.go
@@ -1,15 +1,13 @@
 package event
 
 import (
-	"bufio"
 	"context"
 	"net"
 )
 
 // EventClient is the event struct from hyprland-go.
 type EventClient struct {
-	conn   net.Conn
-	reader *bufio.Reader
+	conn net.Conn
 }
 
 // Event Client interface, right now only used for testing.

--- a/event/event_types.go
+++ b/event/event_types.go
@@ -1,13 +1,15 @@
 package event
 
 import (
+	"bufio"
 	"context"
 	"net"
 )
 
 // EventClient is the event struct from hyprland-go.
 type EventClient struct {
-	conn net.Conn
+	conn   net.Conn
+	reader *bufio.Reader
 }
 
 // Event Client interface, right now only used for testing.


### PR DESCRIPTION
Add a benchmark for `event.Receive()` that shows removing `bufio.Reader()` in this case improves performance.