### PR TITLE
request: make 'j/' prefix for requests optional

### DIFF
--- a/request.go
+++ b/request.go
@@ -24,8 +24,10 @@ const (
 var reqHeader = []byte{'j', '/'}
 var reqSep = []byte{' ', ';'}
 
-func prepareRequest(buf *bytes.Buffer, command string, param string) int {
-	buf.Write(reqHeader)
+func prepareRequest(buf *bytes.Buffer, command string, param string, jsonResp bool) int {
+	if jsonResp {
+		buf.Write(reqHeader)
+	}
 	buf.WriteString(command)
 	buf.WriteByte(reqSep[0])
 	buf.WriteString(param)
@@ -34,8 +36,7 @@ func prepareRequest(buf *bytes.Buffer, command string, param string) int {
 	return buf.Len()
 }
 
-// TODO: add jsonResponse parameter here to allow us to append or not 'j/'
-func prepareRequests(command string, params []string) (requests []RawRequest, err error) {
+func prepareRequests(command string, params []string, jsonResp bool) (requests []RawRequest, err error) {
 	if command == "" {
 		// Panic since this is not supposed to happen, i.e.: only by
 		// misuse since this function is internal
@@ -55,7 +56,9 @@ func prepareRequests(command string, params []string) (requests []RawRequest, er
 				command,
 			)
 		}
-		buf.Write(reqHeader)
+		if jsonResp {
+			buf.Write(reqHeader)
+		}
 		buf.WriteString(command)
 	case 1:
 		request := command + " " + params[0]
@@ -67,7 +70,9 @@ func prepareRequests(command string, params []string) (requests []RawRequest, er
 				request,
 			)
 		}
-		buf.Write(reqHeader)
+		if jsonResp {
+			buf.Write(reqHeader)
+		}
 		buf.WriteString(request)
 	default:
 		// Add [[BATCH]] to the buffer
@@ -106,7 +111,7 @@ func prepareRequests(command string, params []string) (requests []RawRequest, er
 				buf.WriteString(batch)
 			}
 			// Add the contents of the request to the buffer
-			curLen = prepareRequest(buf, command, param)
+			curLen = prepareRequest(buf, command, param, jsonResp)
 		}
 	}
 	// Append any remaining buffer content to requests array
@@ -194,8 +199,8 @@ func unmarshalResponse[T any](response RawResponse, v *T) (T, error) {
 	return *v, nil
 }
 
-func (c *RequestClient) doRequest(command string, params ...string) (response RawResponse, err error) {
-	requests, err := prepareRequests(command, params)
+func (c *RequestClient) doRequest(command string, params []string, jsonResp bool) (response RawResponse, err error) {
+	requests, err := prepareRequests(command, params, jsonResp)
 	if err != nil {
 		return nil, fmt.Errorf("error while preparing request: %w", err)
 	}
@@ -301,7 +306,7 @@ func (c *RequestClient) RawRequest(request RawRequest) (response RawResponse, er
 // Active window command, similar to 'hyprctl activewindow'.
 // Returns a [Window] object.
 func (c *RequestClient) ActiveWindow() (w Window, err error) {
-	response, err := c.doRequest("activewindow")
+	response, err := c.doRequest("activewindow", nil, true)
 	if err != nil {
 		return w, err
 	}
@@ -311,7 +316,7 @@ func (c *RequestClient) ActiveWindow() (w Window, err error) {
 // Get option command, similar to 'hyprctl activeworkspace'.
 // Returns a [Workspace] object.
 func (c *RequestClient) ActiveWorkspace() (w Workspace, err error) {
-	response, err := c.doRequest("activeworkspace")
+	response, err := c.doRequest("activeworkspace", nil, true)
 	if err != nil {
 		return w, err
 	}
@@ -321,7 +326,7 @@ func (c *RequestClient) ActiveWorkspace() (w Workspace, err error) {
 // Animations command, similar to 'hyprctl animations'.
 // Returns a [Animation] object.
 func (c *RequestClient) Animations() (a [][]Animation, err error) {
-	response, err := c.doRequest("animations")
+	response, err := c.doRequest("animations", nil, true)
 	if err != nil {
 		return a, err
 	}
@@ -331,7 +336,7 @@ func (c *RequestClient) Animations() (a [][]Animation, err error) {
 // Binds command, similar to 'hyprctl binds'.
 // Returns a [Bind] object.
 func (c *RequestClient) Binds() (b []Bind, err error) {
-	response, err := c.doRequest("binds")
+	response, err := c.doRequest("binds", nil, true)
 	if err != nil {
 		return b, err
 	}
@@ -341,7 +346,7 @@ func (c *RequestClient) Binds() (b []Bind, err error) {
 // Clients command, similar to 'hyprctl clients'.
 // Returns a [Client] object.
 func (c *RequestClient) Clients() (cl []Client, err error) {
-	response, err := c.doRequest("clients")
+	response, err := c.doRequest("clients", nil, true)
 	if err != nil {
 		return cl, err
 	}
@@ -351,7 +356,7 @@ func (c *RequestClient) Clients() (cl []Client, err error) {
 // ConfigErrors command, similar to `hyprctl configerrors`.
 // Returns a [ConfigError] object.
 func (c *RequestClient) ConfigErrors() (ce []ConfigError, err error) {
-	response, err := c.doRequest("configerrors")
+	response, err := c.doRequest("configerrors", nil, true)
 	if err != nil {
 		return ce, err
 	}
@@ -361,7 +366,7 @@ func (c *RequestClient) ConfigErrors() (ce []ConfigError, err error) {
 // Cursor position command, similar to 'hyprctl cursorpos'.
 // Returns a [CursorPos] object.
 func (c *RequestClient) CursorPos() (cu CursorPos, err error) {
-	response, err := c.doRequest("cursorpos")
+	response, err := c.doRequest("cursorpos", nil, true)
 	if err != nil {
 		return cu, err
 	}
@@ -371,7 +376,7 @@ func (c *RequestClient) CursorPos() (cu CursorPos, err error) {
 // Decorations command, similar to `hyprctl decorations`.
 // Returns a [Decoration] object.
 func (c *RequestClient) Decorations(regex string) (d []Decoration, err error) {
-	response, err := c.doRequest("decorations", regex)
+	response, err := c.doRequest("decorations", []string{regex}, true)
 	if err != nil {
 		return d, err
 	}
@@ -381,7 +386,7 @@ func (c *RequestClient) Decorations(regex string) (d []Decoration, err error) {
 // Devices command, similar to `hyprctl devices`.
 // Returns a [Devices] object.
 func (c *RequestClient) Devices() (d Devices, err error) {
-	response, err := c.doRequest("devices")
+	response, err := c.doRequest("devices", nil, true)
 	if err != nil {
 		return d, err
 	}
@@ -394,7 +399,7 @@ func (c *RequestClient) Devices() (d Devices, err error) {
 // Returns a [Response] list for each parameter, that may be useful for further
 // validations.
 func (c *RequestClient) Dispatch(params ...string) (r []Response, err error) {
-	raw, err := c.doRequest("dispatch", params...)
+	raw, err := c.doRequest("dispatch", params, false)
 	if err != nil {
 		return r, err
 	}
@@ -404,7 +409,7 @@ func (c *RequestClient) Dispatch(params ...string) (r []Response, err error) {
 // Get option command, similar to 'hyprctl getoption'.
 // Returns an [Option] object.
 func (c *RequestClient) GetOption(name string) (o Option, err error) {
-	response, err := c.doRequest("getoption", name)
+	response, err := c.doRequest("getoption", []string{name}, true)
 	if err != nil {
 		return o, err
 	}
@@ -417,7 +422,7 @@ func (c *RequestClient) GetOption(name string) (o Option, err error) {
 // Returns a [Response] list for each parameter, that may be useful for further
 // validations.
 func (c *RequestClient) Keyword(params ...string) (r []Response, err error) {
-	raw, err := c.doRequest("keyword", params...)
+	raw, err := c.doRequest("keyword", params, false)
 	if err != nil {
 		return r, err
 	}
@@ -429,7 +434,7 @@ func (c *RequestClient) Keyword(params ...string) (r []Response, err error) {
 // user to click in the window.
 // Returns a [Response], that may be useful for further validations.
 func (c *RequestClient) Kill() (r Response, err error) {
-	raw, err := c.doRequest("kill")
+	raw, err := c.doRequest("kill", nil, true)
 	if err != nil {
 		return r, err
 	}
@@ -440,7 +445,7 @@ func (c *RequestClient) Kill() (r Response, err error) {
 // Layer command, similar to 'hyprctl layers'.
 // Returns a [Layer] object.
 func (c *RequestClient) Layers() (l Layers, err error) {
-	response, err := c.doRequest("layers")
+	response, err := c.doRequest("layers", nil, true)
 	if err != nil {
 		return l, err
 	}
@@ -450,7 +455,7 @@ func (c *RequestClient) Layers() (l Layers, err error) {
 // Monitors command, similar to 'hyprctl monitors'.
 // Returns a [Monitor] object.
 func (c *RequestClient) Monitors() (m []Monitor, err error) {
-	response, err := c.doRequest("monitors")
+	response, err := c.doRequest("monitors", nil, true)
 	if err != nil {
 		return m, err
 	}
@@ -460,7 +465,7 @@ func (c *RequestClient) Monitors() (m []Monitor, err error) {
 // Reload command, similar to 'hyprctl reload'.
 // Returns a [Response], that may be useful for further validations.
 func (c *RequestClient) Reload() (r Response, err error) {
-	raw, err := c.doRequest("reload")
+	raw, err := c.doRequest("reload", nil, false)
 	if err != nil {
 		return r, err
 	}
@@ -471,7 +476,7 @@ func (c *RequestClient) Reload() (r Response, err error) {
 // Set cursor command, similar to 'hyprctl setcursor'.
 // Returns a [Response], that may be useful for further validations.
 func (c *RequestClient) SetCursor(theme string, size int) (r Response, err error) {
-	raw, err := c.doRequest("setcursor", fmt.Sprintf("%s %d", theme, size))
+	raw, err := c.doRequest("setcursor", []string{fmt.Sprintf("%s %d", theme, size)}, false)
 	if err != nil {
 		return r, err
 	}
@@ -483,7 +488,7 @@ func (c *RequestClient) SetCursor(theme string, size int) (r Response, err error
 // Returns a [Response], that may be useful for further validations.
 // Param cmd can be either 'next', 'prev' or an ID (e.g: 0).
 func (c *RequestClient) SwitchXkbLayout(device string, cmd string) (r Response, err error) {
-	raw, err := c.doRequest("switchxkblayout", fmt.Sprintf("%s %s", device, cmd))
+	raw, err := c.doRequest("switchxkblayout", []string{fmt.Sprintf("%s %s", device, cmd)}, false)
 	if err != nil {
 		return r, err
 	}
@@ -493,7 +498,7 @@ func (c *RequestClient) SwitchXkbLayout(device string, cmd string) (r Response, 
 
 // Splash command, similar to 'hyprctl splash'.
 func (c *RequestClient) Splash() (s string, err error) {
-	response, err := c.doRequest("splash")
+	response, err := c.doRequest("splash", nil, false)
 	if err != nil {
 		return s, err
 	}
@@ -503,7 +508,7 @@ func (c *RequestClient) Splash() (s string, err error) {
 // Version command, similar to 'hyprctl version'.
 // Returns a [Version] object.
 func (c *RequestClient) Version() (v Version, err error) {
-	response, err := c.doRequest("version")
+	response, err := c.doRequest("version", nil, true)
 	if err != nil {
 		return v, err
 	}
@@ -513,7 +518,7 @@ func (c *RequestClient) Version() (v Version, err error) {
 // Workspaces option command, similar to 'hyprctl workspaces'.
 // Returns a [Workspace] object.
 func (c *RequestClient) Workspaces() (w []Workspace, err error) {
-	response, err := c.doRequest("workspaces")
+	response, err := c.doRequest("workspaces", nil, true)
 	if err != nil {
 		return w, err
 	}

--- a/request.go
+++ b/request.go
@@ -36,6 +36,7 @@ func prepareRequest(buf *bytes.Buffer, command string, param string, jsonResp bo
 	return buf.Len()
 }
 
+// TODO: needs refactor, the logic is all over the place
 func prepareRequests(command string, params []string, jsonResp bool) (requests []RawRequest, err error) {
 	if command == "" {
 		// Panic since this is not supposed to happen, i.e.: only by


### PR DESCRIPTION
Not every command supports JSON response (e.g.: Dispatch), and forcing it in every command not only send an unnecessary request to Hyprland IPC, but also can make it more fragile since if a future Hyprland version implement JSON response for an existing command, this command will break.

This commit adds a explicit `jsonResp` parameter to `prepareRequests()` so we can differentiate between commands that return JSON response for those that doesn't, and we will only prefix the request with 'j/' if `jsonResp == true`.