### PR TITLE
request: have monitor command return disabled monitors

### DIFF
--- a/request.go
+++ b/request.go
@@ -457,7 +457,7 @@ func (c *RequestClient) Layers() (l Layers, err error) {
 // Monitors command, similar to 'hyprctl monitors'.
 // Returns a [Monitor] object.
 func (c *RequestClient) Monitors() (m []Monitor, err error) {
-	response, err := c.doRequest("monitors", nil, true)
+	response, err := c.doRequest("monitors all", nil, true)
 	if err != nil {
 		return m, err
 	}


### PR DESCRIPTION
The current implementation does not return disabled monitors. I had thought to add an argument to the `Monitors()` that would allow a user to choose whether or not to return all monitors, but the current monitor option already has a `Disabled bool` field on it, so it should be trivial to filter out the disabled monitors.

Let me know if you'd rather provide an argument to toggle returning the disabled monitors or not.