### PR TITLE
.github/nix: switch to cachix/install-nix-action, upgrade actions/checkout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '=1.21'
 

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -10,9 +10,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: build package
       run: nix build -L


### PR DESCRIPTION
See https://determinate.systems/blog/installer-dropping-upstream/ for a reason.